### PR TITLE
Dynamic expando object

### DIFF
--- a/app/Simpler/Data/Tasks/BuildDynamic.cs
+++ b/app/Simpler/Data/Tasks/BuildDynamic.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Dynamic;
 
@@ -39,15 +40,15 @@ namespace Simpler.Data.Tasks
 
         public override void Execute()
         {
-            Out.Object = new Dynamic();
-
+            Out.Object = new ExpandoObject();
+            var OutObject = Out.Object as IDictionary<string, Object>;
             for (var i = 0; i < In.DataRecord.FieldCount; i++)
             {
                 var columnName = In.DataRecord.GetName(i);
                 var columnValue = In.DataRecord[columnName];
                 if (columnValue.GetType() != typeof(System.DBNull))
                 {
-                    Out.Object.AddMember(columnName, columnValue);
+                    OutObject.Add(columnName, columnValue);
                 }
             }
         }


### PR DESCRIPTION
I switched from using Dynamic to using ExpandoObject because ExpandoObject offers better serialization support.

Fetch Many Example

``` c#
public class FetchStuff : OutTask<FetchStuff.Output>
{
    public class Output
    {
        public Object[] Stuff { get; set; }
    }

    public override void Execute()
    {
        using(var connection = Db.Connect("MyConnectionString"))
        {
            const string sql = "......."
            Out.Stuff = Db.GetMany(connection, sql);
        }
    }
}
```

Fetch One Example

``` c#
public class FetchThing  : OutTask<FetchThing  .Output>
{
    public class Output
    {
        public Object Thing { get; set; }
    }

    public override void Execute()
    {
        using(var connection = Db.Connect("MyConnectionString"))
        {
            const string sql = "......."
            Out.Thing = Db.GetOne(connection, sql);
        }
    }
}
```
