### PR TITLE
add sugar for executing tasks in parallel

### DIFF
--- a/app/Simpler.Tests/Core/Mocks/MockParentTask.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockParentTask.cs
@@ -4,13 +4,14 @@ namespace Simpler.Tests.Core.Mocks
 {
     public class MockParentTask : Task
     {
-        public bool SubTaskWasInjected { get; private set; }
+        public bool SubtaskWasExecuted { get; set; }
 
         public MockSubTask<DateTime> MockSubClass { get; set; }
 
         public override void Execute()
         {
-            SubTaskWasInjected = (MockSubClass != null);
+            MockSubClass.Execute();
+            SubtaskWasExecuted = MockSubClass.WasExecuted;
         }
     }
 }

--- a/app/Simpler.Tests/Core/Mocks/MockSlowTask.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockSlowTask.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Simpler.Tests.Core.Mocks
+{
+    public class MockSlowTask : Task
+    {
+        public override void Execute()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                Thread.Sleep(50);
+            }
+        }
+    }
+}

--- a/app/Simpler.Tests/Core/Mocks/MockSubTask.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockSubTask.cs
@@ -2,14 +2,15 @@ using System;
 
 namespace Simpler.Tests.Core.Mocks
 {
-	public class MockSubTask<T> : Task, IDisposable
-	{
+    public class MockSubTask<T> : Task, IDisposable
+    {
+        public bool DisposeWasCalled { get; set; }
+        public bool WasExecuted { get; set; }
+
         public override void Execute()
         {
-            throw new NotImplementedException();
+            WasExecuted = true;
         }
-
-        public bool DisposeWasCalled { get; set; }
 
         public void Dispose()
         {

--- a/app/Simpler.Tests/FakeTest.cs
+++ b/app/Simpler.Tests/FakeTest.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using Simpler.Tests.Core.Mocks;
+
+namespace Simpler.Tests
+{
+    [TestFixture]
+    public class FakeTest
+    {
+        [Test]
+        public void should_fake_subtasks()
+        {
+            // Arrange
+            var mockParentTask = Task.New<MockParentTask>();
+
+            // Act
+            Fake.Subtasks(mockParentTask);
+            mockParentTask.Execute();
+
+            // Assert
+            Assert.That(mockParentTask.SubtaskWasExecuted, Is.False);
+        }
+    }
+}

--- a/app/Simpler.Tests/ParallelTest.cs
+++ b/app/Simpler.Tests/ParallelTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics;
+using NUnit.Framework;
+using Simpler.Tests.Core.Mocks;
+
+namespace Simpler.Tests
+{
+    [TestFixture]
+    public class ParallelTest
+    {
+        [Test]
+        public void can_run_tasks_faster_in_parallel()
+        {
+            // Arrange
+            Task[] tasks = new[] { Task.New<MockSlowTask>(), Task.New<MockSlowTask>() };
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            foreach (var task in tasks)
+            {
+                task.Execute();
+            }
+            var sequential = stopwatch.ElapsedMilliseconds;
+
+            stopwatch.Restart();
+            Parallel.Execute(tasks);
+            var parallel = stopwatch.ElapsedMilliseconds;
+
+            // Assert
+            Assert.That(parallel, Is.LessThan(sequential));
+        }
+    }
+}

--- a/app/Simpler.Tests/Simpler.Tests.csproj
+++ b/app/Simpler.Tests/Simpler.Tests.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Core\Mocks\MockSlowTask.cs" />
     <Compile Include="FakeTest.cs" />
     <Compile Include="Core\Mocks\MockComplexObject.cs" />
     <Compile Include="Core\Mocks\MockException.cs" />
@@ -73,6 +74,7 @@
     <Compile Include="Data\Tasks\FetchManyTest.cs" />
     <Compile Include="Data\Tasks\FindParameters.cs" />
     <Compile Include="Examples.cs" />
+    <Compile Include="ParallelTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TaskTest.cs" />
   </ItemGroup>

--- a/app/Simpler.Tests/Simpler.Tests.csproj
+++ b/app/Simpler.Tests/Simpler.Tests.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FakeTest.cs" />
     <Compile Include="Core\Mocks\MockComplexObject.cs" />
     <Compile Include="Core\Mocks\MockException.cs" />
     <Compile Include="Core\Mocks\MockFirstAttribute.cs" />

--- a/app/Simpler/Fake.cs
+++ b/app/Simpler/Fake.cs
@@ -29,5 +29,23 @@ namespace Simpler
 
             return (TTask)createTask.Out.TaskInstance;
         }
+
+        public static void Subtasks(Task task)
+        {
+            var properties = task.GetType().GetProperties();
+            foreach (var propertyX in properties)
+            {
+                if (propertyX.PropertyType.IsSubclassOf(typeof(Task)) && (propertyX.CanWrite))
+                {
+                    var interceptor = new ExecuteInterceptor(invocation => { });
+
+                    var createTask = Simpler.Task.New<CreateTask>();
+                    createTask.In.TaskType = propertyX.PropertyType;
+                    createTask.In.ExecuteInterceptor = interceptor;
+                    createTask.Execute();
+                    propertyX.SetValue(task, createTask.Out.TaskInstance, null);
+                }
+            }
+        }
     }
 }

--- a/app/Simpler/Parallel.cs
+++ b/app/Simpler/Parallel.cs
@@ -1,0 +1,10 @@
+﻿namespace Simpler
+{
+    public static class Parallel
+    {
+        public static void Execute(params Task[] tasks)
+        {
+            System.Threading.Tasks.Parallel.ForEach(tasks, task => task.Execute());
+        }
+    }
+}

--- a/app/Simpler/Parallel.cs
+++ b/app/Simpler/Parallel.cs
@@ -1,10 +1,22 @@
 ﻿namespace Simpler
 {
-    public static class Parallel
+    public class Parallel
     {
+        public static bool Enabled = true;
+
         public static void Execute(params Task[] tasks)
         {
-            System.Threading.Tasks.Parallel.ForEach(tasks, task => task.Execute());
+            if (Enabled)
+            {
+                System.Threading.Tasks.Parallel.ForEach(tasks, task => task.Execute());
+            }
+            else
+            {
+                foreach (var task in tasks)
+                {
+                    task.Execute();
+                }
+            }
         }
     }
 }

--- a/app/Simpler/Simpler.csproj
+++ b/app/Simpler/Simpler.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Simpler</RootNamespace>
     <AssemblyName>Simpler</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -68,6 +68,7 @@
     <Compile Include="InOutTask.cs" />
     <Compile Include="InTask.cs" />
     <Compile Include="OutTask.cs" />
+    <Compile Include="Parallel.cs" />
     <Compile Include="Stats.cs" />
     <Compile Include="Task.cs" />
     <Compile Include="OverrideAttribute.cs" />


### PR DESCRIPTION
This requires #6 for it to work consistently (no tests that can prove it yet, but `DynamicProxy` broke down with running parallel tasks in a ASP.NET MVC application).

Tasks
- [ ] Needs more testing, specifically with handling cases where one or more of the tasks throws an exception
