### PR TITLE
renames to make Simpler less wordy

### DIFF
--- a/app/Simpler.Tests/Core/Mocks/MockFirstAttribute.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockFirstAttribute.cs
@@ -4,17 +4,17 @@ namespace Simpler.Tests.Core.Mocks
 {
     public class MockFirstAttribute : EventsAttribute
     {
-        public override void BeforeExecute(Task task)
+        public override void BeforeExecute(T task)
         {
             ((MockTaskWithAttributes)task).CallbackQueue.Enqueue("First.Before");
         }
 
-        public override void AfterExecute(Task task)
+        public override void AfterExecute(T task)
         {
             ((MockTaskWithAttributes)task).CallbackQueue.Enqueue("First.After");
         }
 
-        public override void OnError(Task task, Exception exception)
+        public override void OnError(T task, Exception exception)
         {
             ((MockTaskWithAttributes)task).CallbackQueue.Enqueue("First.OnError");
         }

--- a/app/Simpler.Tests/Core/Mocks/MockParentTask.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockParentTask.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Simpler.Tests.Core.Mocks
 {
-    public class MockParentTask : Task
+    public class MockParentTask : T
     {
         public bool SubTaskWasInjected { get; private set; }
 

--- a/app/Simpler.Tests/Core/Mocks/MockSecondAttribute.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockSecondAttribute.cs
@@ -4,17 +4,17 @@ namespace Simpler.Tests.Core.Mocks
 {
     public class MockSecondAttribute : EventsAttribute
     {
-        public override void BeforeExecute(Task task)
+        public override void BeforeExecute(T task)
         {
             ((MockTaskWithAttributes)task).CallbackQueue.Enqueue("Second.Before");
         }
 
-        public override void AfterExecute(Task task)
+        public override void AfterExecute(T task)
         {
             ((MockTaskWithAttributes)task).CallbackQueue.Enqueue("Second.After");
         }
 
-        public override void OnError(Task task, Exception exception)
+        public override void OnError(T task, Exception exception)
         {
             ((MockTaskWithAttributes)task).CallbackQueue.Enqueue("Second.OnError");
         }

--- a/app/Simpler.Tests/Core/Mocks/MockSubTask.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockSubTask.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Simpler.Tests.Core.Mocks
 {
-	public class MockSubTask<T> : Task, IDisposable
+	public class MockSubTask<T> : Simpler.T, IDisposable
 	{
         public override void Execute()
         {

--- a/app/Simpler.Tests/Core/Mocks/MockTask.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockTask.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Simpler.Tests.Core.Mocks
 {
-    public class MockTask : Task
+    public class MockTask : T
     {
         public override void Execute()
         {

--- a/app/Simpler.Tests/Core/Mocks/MockTaskWithAttributes.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockTaskWithAttributes.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Simpler.Tests.Core.Mocks
 {
     [MockFirst, MockSecond]
-    public class MockTaskWithAttributes : Task
+    public class MockTaskWithAttributes : T
     {
         public MockTaskWithAttributes()
         {

--- a/app/Simpler.Tests/Core/Mocks/MockTaskWithOverrideAttribute.cs
+++ b/app/Simpler.Tests/Core/Mocks/MockTaskWithOverrideAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Simpler.Tests.Core.Mocks
 {
     [MockOverride]
-    public class MockTaskWithOverrideAttribute : Task
+    public class MockTaskWithOverrideAttribute : T
     {
         public DateTime OverrideWasCalledTime;
         public DateTime WasExecutedTime;

--- a/app/Simpler.Tests/Core/Tasks/CreateTaskTest.cs
+++ b/app/Simpler.Tests/Core/Tasks/CreateTaskTest.cs
@@ -11,7 +11,7 @@ namespace Simpler.Tests.Core.Tasks
         public void should_just_provide_instance_if_given_type_is_not_decorated_with_execution_callbacks_attribute()
         {
             // Arrange
-            var task = Task.New<CreateTask>();
+            var task = T.New<CreateTask>();
             task.In.TaskType = typeof (MockTask);
 
             // Act
@@ -26,7 +26,7 @@ namespace Simpler.Tests.Core.Tasks
         public void should_provide_proxy_instance_if_given_type_is_decorated_with_execution_callbacks_attribute()
         {
             // Arrange
-            var task = Task.New<CreateTask>();
+            var task = T.New<CreateTask>();
             task.In.TaskType = typeof (MockTaskWithAttributes);
 
             // Act

--- a/app/Simpler.Tests/Core/Tasks/ExecuteTaskTest.cs
+++ b/app/Simpler.Tests/Core/Tasks/ExecuteTaskTest.cs
@@ -65,7 +65,7 @@ namespace Simpler.Tests.Core.Tasks
         public void should_send_notifications_before_and_after_the_task_is_executed()
         {
             // Arrange
-            var task = Task.New<ExecuteTask>();
+            var task = T.New<ExecuteTask>();
 
             var taskWithAttributes = new MockTaskWithAttributes();
             task.In.Task = taskWithAttributes;
@@ -85,7 +85,7 @@ namespace Simpler.Tests.Core.Tasks
         public void should_send_notifications_if_task_execution_throws_an_unhandled_exception()
         {
             // Arrange
-            var task = Task.New<ExecuteTask>();
+            var task = T.New<ExecuteTask>();
 
             var taskWithAttributesThatThrows = new MockTaskThatThrowsWithAttributes();
             task.In.Task = taskWithAttributesThatThrows;
@@ -105,7 +105,7 @@ namespace Simpler.Tests.Core.Tasks
         public void should_send_notifications_after_the_task_is_executed_even_if_exception_occurs()
         {
             // Arrange
-            var task = Task.New<ExecuteTask>();
+            var task = T.New<ExecuteTask>();
 
             var taskWithAttributesThatThrows = new MockTaskThatThrowsWithAttributes();
             task.In.Task = taskWithAttributesThatThrows;
@@ -139,7 +139,7 @@ namespace Simpler.Tests.Core.Tasks
         public void should_allow_the_task_execution_to_be_overriden()
         {
             // Arrange
-            var task = Task.New<ExecuteTask>();
+            var task = T.New<ExecuteTask>();
 
             var taskWithOverride = new MockTaskWithOverrideAttribute();
             task.In.Task = taskWithOverride;

--- a/app/Simpler.Tests/Core/Tasks/InjectTasksTest.cs
+++ b/app/Simpler.Tests/Core/Tasks/InjectTasksTest.cs
@@ -13,7 +13,7 @@ namespace Simpler.Tests.Core.Tasks
         {
             // Arrange
             var mockParentTask = new MockParentTask();
-            var task = new InjectTasks { In = { TaskContainingSubTasks = mockParentTask } };
+            var task = new InjectTasks { In = { Task = mockParentTask } };
 
             // Act
             task.Execute();
@@ -28,13 +28,13 @@ namespace Simpler.Tests.Core.Tasks
             // Arrange
             var mockDifferentSubTask = new MockSubTask<DateTime>();
             var mockParentTask = new MockParentTask { MockSubClass = mockDifferentSubTask };
-            var task = new InjectTasks { In = { TaskContainingSubTasks = mockParentTask } };
+            var task = new InjectTasks { In = { Task = mockParentTask } };
 
             // Act
             task.Execute();
 
             // Assert
-            Assert.That(task.Out.InjectedSubTaskPropertyNames.Length, Is.EqualTo(0));
+            Assert.That(task.Out.InjectedTaskPropertyNames.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -42,13 +42,13 @@ namespace Simpler.Tests.Core.Tasks
         {
             // Arrange
             var mockParentTask = new MockParentTask();
-            var task = new InjectTasks { In = { TaskContainingSubTasks = mockParentTask } };
+            var task = new InjectTasks { In = { Task = mockParentTask } };
 
             // Act
             task.Execute();
 
             // Assert
-            Assert.That(task.Out.InjectedSubTaskPropertyNames[0], Is.EqualTo(typeof(MockSubTask<DateTime>).FullName));
+            Assert.That(task.Out.InjectedTaskPropertyNames[0], Is.EqualTo(typeof(MockSubTask<DateTime>).FullName));
         }
     }
 }

--- a/app/Simpler.Tests/Data/Tasks/BuildObjectTest.cs
+++ b/app/Simpler.Tests/Data/Tasks/BuildObjectTest.cs
@@ -13,7 +13,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_create_an_instance_of_given_object_type()
         {
             // Arrange
-            var task = Task.New<BuildObject<MockObject>>();
+            var task = T.New<BuildObject<MockObject>>();
 
             var mockDataRecord = new Mock<IDataRecord>();
             task.In.DataRecord = mockDataRecord.Object;
@@ -29,7 +29,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_populate_object_using_all_columns_in_the_data_record()
         {
             // Arrange
-            var task = Task.New<BuildObject<MockObject>>();
+            var task = T.New<BuildObject<MockObject>>();
 
             var mockDataRecord = new Mock<IDataRecord>();
             mockDataRecord.Setup(dataRecord => dataRecord.FieldCount).Returns(2);
@@ -51,7 +51,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_throw_exception_if_a_data_record_column_is_not_a_property_of_the_object_class()
         {
             // Arrange
-            var task = Task.New<BuildObject<MockObject>>();
+            var task = T.New<BuildObject<MockObject>>();
 
             var mockDataRecord = new Mock<IDataRecord>();
             mockDataRecord.Setup(dataRecord => dataRecord.FieldCount).Returns(1);
@@ -67,7 +67,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_allow_object_to_have_properties_that_dont_have_matching_columns_in_the_data_record()
         {
             // Arrange
-            var task = Task.New<BuildObject<MockObject>>();
+            var task = T.New<BuildObject<MockObject>>();
 
             var mockDataRecord = new Mock<IDataRecord>();
             mockDataRecord.Setup(dataRecord => dataRecord.FieldCount).Returns(1);
@@ -88,7 +88,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_build_enum_properties()
         {
             // Arrange
-            var task = Task.New<BuildObject<MockObject>>();
+            var task = T.New<BuildObject<MockObject>>();
 
             var mockDataRecord = new Mock<IDataRecord>();
             mockDataRecord.Setup(dataRecord => dataRecord.FieldCount).Returns(1);

--- a/app/Simpler.Tests/Data/Tasks/BuildParametersTest.cs
+++ b/app/Simpler.Tests/Data/Tasks/BuildParametersTest.cs
@@ -14,7 +14,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_create_parameters_for_any_parameters_found_in_the_command_text_with_matching_properties_in_the_static_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -40,7 +40,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_create_parameters_for_any_parameters_found_in_the_command_text_with_matching_properties_in_the_anonymous_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -65,7 +65,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_set_parameter_to_the_value_found_in_the_matching_property_of_the_static_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -91,7 +91,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_set_parameter_to_the_value_found_in_the_matching_property_of_the_anonymous_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -116,7 +116,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_ignore_parameters_found_in_the_command_text_without_matching_properties_in_the_static_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -140,7 +140,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_ignore_parameters_found_in_the_command_text_without_matching_properties_in_the_anonymous_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -164,7 +164,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_set_parameter_to_dbnull_if_value_found_in_the_matching_property_of_the_static_object_is_null()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -190,7 +190,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_set_parameter_to_dbnull_if_value_found_in_the_matching_property_of_the_anonymous_object_is_dbnull()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -215,7 +215,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_support_setting_parameter_using_a_complex_static_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();
@@ -242,7 +242,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_support_setting_parameter_using_a_complex_anonymous_object()
         {
             // Arrange
-            var task = Task.New<BuildParameters>();
+            var task = T.New<BuildParameters>();
 
             var mockDbCommand = new Mock<IDbCommand> { DefaultValue = DefaultValue.Mock };
             var mockDbDataParameter = new Mock<IDbDataParameter>();

--- a/app/Simpler.Tests/Data/Tasks/FetchManyTest.cs
+++ b/app/Simpler.Tests/Data/Tasks/FetchManyTest.cs
@@ -15,7 +15,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_return_an_object_for_each_record_returned_by_the_select_command()
         {
             // Arrange
-            var task = Task.New<FetchMany<MockObject>>();
+            var task = T.New<FetchMany<MockObject>>();
 
             var table = new DataTable();
             table.Columns.Add("Name", Type.GetType("System.String"));

--- a/app/Simpler.Tests/Data/Tasks/FindParameters.cs
+++ b/app/Simpler.Tests/Data/Tasks/FindParameters.cs
@@ -10,7 +10,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameters_starting_with_an_at_symbol()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 @"
                 select whatever from table where something = @something and something_else is true
@@ -27,7 +27,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameters_starting_with_a_colon()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 @"
                 select whatever from table where something = :something and something_else is true
@@ -44,7 +44,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameters_that_contain_an_underscore()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 @"
                 select whatever from table where something = @some_thing and something_else is true
@@ -61,7 +61,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameters_that_contain_a_dot()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 @"
                 select whatever from table where something = @complex.object and something_else is true
@@ -78,7 +78,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameters_that_contain_a_number()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 @"
                 select whatever from table where something = @some1thing1 and something_else is true
@@ -95,7 +95,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameters_followed_by_a_comma()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 @"
                 insert into table set something = @something, something_else = 'whatever'
@@ -112,7 +112,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameters_followed_by_a_carriage_return()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 "select whatever from table where something = @something\n and something_else is true";
 
@@ -135,7 +135,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_find_parameter_at_the_very_end_of_the_command_text()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 "select whatever from table where something = @something";
 
@@ -150,7 +150,7 @@ namespace Simpler.Tests.Data.Tasks
         public void should_only_return_one_instance_of_parameter_name_even_if_parameter_exists_in_command_text_more_than_once()
         {
             // Arrange
-            var task = Task.New<FindParameters>();
+            var task = T.New<FindParameters>();
             task.In.CommandText =
                 @"
                 select whatever from table where something = @something and somethingelsealso = @something

--- a/app/Simpler.Tests/Examples.cs
+++ b/app/Simpler.Tests/Examples.cs
@@ -6,7 +6,7 @@ using Simpler.Data.Tasks;
 
 namespace Simpler
 {
-    public class OldAsk : Task
+    public class OldAsk : T
     {
         // Inputs
         public string Question { get; set; }
@@ -23,7 +23,7 @@ namespace Simpler
         }
     }
 
-    public class Ask : InOutTask<Ask.Input, Ask.Output>
+    public class Ask : IO<Ask.Input, Ask.Output>
     {
         public class Input
         {
@@ -46,24 +46,24 @@ namespace Simpler
 
     public class LogAttribute : EventsAttribute
     {
-        public override void BeforeExecute(Task task)
+        public override void BeforeExecute(T task)
         {
             Console.WriteLine(String.Format("{0} started.", task.Name));
         }
 
-        public override void AfterExecute(Task task)
+        public override void AfterExecute(T task)
         {
             Console.WriteLine(String.Format("{0} finished.", task.Name));
         }
 
-        public override void OnError(Task task, Exception exception)
+        public override void OnError(T task, Exception exception)
         {
             Console.WriteLine(String.Format("{0} bombed; error message: {1}.", task.Name, exception.Message));
         }
     }
 
     [Log]
-    public class BeAnnoying : InTask<BeAnnoying.Input>
+    public class BeAnnoying : I<BeAnnoying.Input>
     {
         public class Input
         {
@@ -89,7 +89,7 @@ namespace Simpler
     {
         Program()
         {
-            var beAnnoying = Task.New<BeAnnoying>();
+            var beAnnoying = T.New<BeAnnoying>();
             beAnnoying.In.AnnoyanceLevel = 10;
             beAnnoying.Execute();
         }
@@ -100,7 +100,7 @@ namespace Simpler
         public string Name { get; set; }
     }
 
-    public class OldFetchCertainStuff : InOutTask<OldFetchCertainStuff.Input, OldFetchCertainStuff.Output>
+    public class OldFetchCertainStuff : IO<OldFetchCertainStuff.Input, OldFetchCertainStuff.Output>
     {
         public class Input
         {
@@ -145,7 +145,7 @@ namespace Simpler
         }
     }
 
-    public class FetchCertainStuff : InOutTask<FetchCertainStuff.Input, FetchCertainStuff.Output>
+    public class FetchCertainStuff : IO<FetchCertainStuff.Input, FetchCertainStuff.Output>
     {
         public class Input
         {
@@ -187,7 +187,7 @@ namespace Simpler
         public void should_return_9_pocos()
         {
             // Arrange
-            var task = Task.New<FetchCertainStuff>();
+            var task = T.New<FetchCertainStuff>();
             task.In.SomeCriteria = "criteria";
 
             // Act

--- a/app/Simpler.Tests/Examples.cs
+++ b/app/Simpler.Tests/Examples.cs
@@ -23,14 +23,14 @@ namespace Simpler
         }
     }
 
-    public class Ask : IO<Ask.Input, Ask.Output>
+    public class Ask : IO<Ask.Ins, Ask.Outs>
     {
-        public class Input
+        public class Ins
         {
             public string Question { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public string Answer { get; set; }
         }
@@ -63,9 +63,9 @@ namespace Simpler
     }
 
     [Log]
-    public class BeAnnoying : I<BeAnnoying.Input>
+    public class BeAnnoying : I<BeAnnoying.Ins>
     {
-        public class Input
+        public class Ins
         {
             public int AnnoyanceLevel { get; set; }
         }
@@ -100,14 +100,14 @@ namespace Simpler
         public string Name { get; set; }
     }
 
-    public class OldFetchCertainStuff : IO<OldFetchCertainStuff.Input, OldFetchCertainStuff.Output>
+    public class OldFetchCertainStuff : IO<OldFetchCertainStuff.Ins, OldFetchCertainStuff.Outs>
     {
-        public class Input
+        public class Ins
         {
             public string SomeCriteria { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public Stuff[] Stuff { get; set; }
         }
@@ -145,14 +145,14 @@ namespace Simpler
         }
     }
 
-    public class FetchCertainStuff : IO<FetchCertainStuff.Input, FetchCertainStuff.Output>
+    public class FetchCertainStuff : IO<FetchCertainStuff.Ins, FetchCertainStuff.Outs>
     {
-        public class Input
+        public class Ins
         {
             public string SomeCriteria { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public Stuff[] Stuff { get; set; }
         }

--- a/app/Simpler.Tests/TaskTest.cs
+++ b/app/Simpler.Tests/TaskTest.cs
@@ -10,7 +10,7 @@ namespace Simpler.Tests
         [Test]
         public void should_create_new_task()
         {
-            var mockTask = Task.New<MockTask>();
+            var mockTask = T.New<MockTask>();
 
             Check.That(mockTask != null, "MockTask was not created.");
         }
@@ -18,7 +18,7 @@ namespace Simpler.Tests
         [Test]
         public void should_provide_underlying_task_name()
         {
-            var mockTask = Task.New<MockTask>();
+            var mockTask = T.New<MockTask>();
             const string expectedName = "Simpler.Tests.Core.Mocks.MockTask";
 
             Check.That(mockTask.Name == expectedName, "Expected name to be {0}.", expectedName);
@@ -27,13 +27,13 @@ namespace Simpler.Tests
         [Test]
         public void should_throw_if_attempt_new_InjectTasks()
         {
-            Check.Throws(() => Task.New<InjectTasks>());
+            Check.Throws(() => T.New<InjectTasks>());
         }
 
         [Test]
         public void should_throw_if_attempt_new_DisposeTasks()
         {
-            Check.Throws<CheckException>(() => Task.New<DisposeTasks>());
+            Check.Throws<CheckException>(() => T.New<DisposeTasks>());
         }
     }
 }

--- a/app/Simpler/Core/FakeInvocation.cs
+++ b/app/Simpler/Core/FakeInvocation.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using Castle.DynamicProxy;
 
 namespace Simpler.Core

--- a/app/Simpler/Core/FakeInvocation.cs
+++ b/app/Simpler/Core/FakeInvocation.cs
@@ -7,15 +7,15 @@ using Castle.DynamicProxy;
 
 namespace Simpler.Core
 {
-    public class FakeInvocation<TTask> : IInvocation where TTask : Task
+    public class FakeInvocation<TTask> : IInvocation where TTask : T
     {
-        public FakeInvocation(Task task, Action<TTask> execute)
+        public FakeInvocation(T task, Action<TTask> execute)
         {
             _task = task;
             _execute = execute;
         }
 
-        readonly Task _task;
+        readonly T _task;
         readonly Action<TTask> _execute;
 
         public void Proceed()

--- a/app/Simpler/Core/InjectTasksAttribute.cs
+++ b/app/Simpler/Core/InjectTasksAttribute.cs
@@ -8,19 +8,19 @@ namespace Simpler.Core
     {
         readonly List<string> _injectedSubTaskPropertyNames = new List<string>();
 
-        public override void BeforeExecute(Task task)
+        public override void BeforeExecute(T task)
         {
             var inject = new InjectTasks { In = { TaskContainingSubTasks = task } };
             inject.Execute();
             _injectedSubTaskPropertyNames.AddRange(inject.Out.InjectedSubTaskPropertyNames);
         }
 
-        public override void AfterExecute(Task task)
+        public override void AfterExecute(T task)
         {
             var dispose = new DisposeTasks { In = { Owner = task, InjectedTaskNames = _injectedSubTaskPropertyNames.ToArray() } };
             dispose.Execute();
         }
 
-        public override void OnError(Task task, Exception exception) { }
+        public override void OnError(T task, Exception exception) { }
     }
 }

--- a/app/Simpler/Core/InjectTasksAttribute.cs
+++ b/app/Simpler/Core/InjectTasksAttribute.cs
@@ -6,18 +6,18 @@ namespace Simpler.Core
 {
     public class InjectTasksAttribute : EventsAttribute
     {
-        readonly List<string> _injectedSubTaskPropertyNames = new List<string>();
+        readonly List<string> _injectedTaskPropertyNames = new List<string>();
 
         public override void BeforeExecute(T task)
         {
-            var inject = new InjectTasks { In = { TaskContainingSubTasks = task } };
+            var inject = new InjectTasks { In = { Task = task } };
             inject.Execute();
-            _injectedSubTaskPropertyNames.AddRange(inject.Out.InjectedSubTaskPropertyNames);
+            _injectedTaskPropertyNames.AddRange(inject.Out.InjectedTaskPropertyNames);
         }
 
         public override void AfterExecute(T task)
         {
-            var dispose = new DisposeTasks { In = { Owner = task, InjectedTaskNames = _injectedSubTaskPropertyNames.ToArray() } };
+            var dispose = new DisposeTasks { In = { Owner = task, InjectedTaskNames = _injectedTaskPropertyNames.ToArray() } };
             dispose.Execute();
         }
 

--- a/app/Simpler/Core/Tasks/CreateTask.cs
+++ b/app/Simpler/Core/Tasks/CreateTask.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Simpler.Core.Tasks
 {
-    public class CreateTask : InOutTask<CreateTask.Input, CreateTask.Output>
+    public class CreateTask : IO<CreateTask.Input, CreateTask.Output>
     {
         static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();
 
@@ -28,7 +28,7 @@ namespace Simpler.Core.Tasks
                     invocation =>
                         {
                             if (ExecuteTask == null) ExecuteTask = new ExecuteTask();
-                            ExecuteTask.In.Task = (Task)invocation.InvocationTarget;
+                            ExecuteTask.In.Task = (T)invocation.InvocationTarget;
                             ExecuteTask.In.Invocation = invocation;
                             ExecuteTask.Execute();
                         });

--- a/app/Simpler/Core/Tasks/CreateTask.cs
+++ b/app/Simpler/Core/Tasks/CreateTask.cs
@@ -3,17 +3,17 @@ using System;
 
 namespace Simpler.Core.Tasks
 {
-    public class CreateTask : IO<CreateTask.Input, CreateTask.Output>
+    public class CreateTask : IO<CreateTask.Ins, CreateTask.Outs>
     {
         static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();
 
-        public class Input
+        public class Ins
         {
             public Type TaskType { get; set; }
             public ExecuteInterceptor ExecuteInterceptor { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public object TaskInstance { get; set; }
         }

--- a/app/Simpler/Core/Tasks/DisposeTasks.cs
+++ b/app/Simpler/Core/Tasks/DisposeTasks.cs
@@ -4,9 +4,9 @@ using System.Linq;
 
 namespace Simpler.Core.Tasks
 {
-    public class DisposeTasks : I<DisposeTasks.Input>
+    public class DisposeTasks : I<DisposeTasks.Ins>
     {
-        public class Input
+        public class Ins
         {
             public T Owner { get; set; }
             public string[] InjectedTaskNames { get; set; }

--- a/app/Simpler/Core/Tasks/DisposeTasks.cs
+++ b/app/Simpler/Core/Tasks/DisposeTasks.cs
@@ -4,11 +4,11 @@ using System.Linq;
 
 namespace Simpler.Core.Tasks
 {
-    public class DisposeTasks : InTask<DisposeTasks.Input>
+    public class DisposeTasks : I<DisposeTasks.Input>
     {
         public class Input
         {
-            public Task Owner { get; set; }
+            public T Owner { get; set; }
             public string[] InjectedTaskNames { get; set; }
         }
 
@@ -18,7 +18,7 @@ namespace Simpler.Core.Tasks
             var properties = In.Owner.GetType().GetProperties();
 
             foreach (var property in properties.Where(
-                property => property.PropertyType.IsSubclassOf(typeof(Task))
+                property => property.PropertyType.IsSubclassOf(typeof(T))
                     &&
                     taskNames.Contains(property.PropertyType.FullName)
                     &&

--- a/app/Simpler/Core/Tasks/ExecuteTask.cs
+++ b/app/Simpler/Core/Tasks/ExecuteTask.cs
@@ -3,11 +3,11 @@ using Castle.DynamicProxy;
 
 namespace Simpler.Core.Tasks
 {
-    public class ExecuteTask : InTask<ExecuteTask.Input>
+    public class ExecuteTask : I<ExecuteTask.Input>
     {
         public class Input
         {
-            public Task Task { get; set; }
+            public T Task { get; set; }
             public IInvocation Invocation { get; set; }
         }
 

--- a/app/Simpler/Core/Tasks/ExecuteTask.cs
+++ b/app/Simpler/Core/Tasks/ExecuteTask.cs
@@ -3,9 +3,9 @@ using Castle.DynamicProxy;
 
 namespace Simpler.Core.Tasks
 {
-    public class ExecuteTask : I<ExecuteTask.Input>
+    public class ExecuteTask : I<ExecuteTask.Ins>
     {
-        public class Input
+        public class Ins
         {
             public T Task { get; set; }
             public IInvocation Invocation { get; set; }

--- a/app/Simpler/Core/Tasks/InjectTasks.cs
+++ b/app/Simpler/Core/Tasks/InjectTasks.cs
@@ -2,14 +2,14 @@ using System.Collections.Generic;
 
 namespace Simpler.Core.Tasks
 {
-    public class InjectTasks : IO<InjectTasks.Input, InjectTasks.Output>
+    public class InjectTasks : IO<InjectTasks.Ins, InjectTasks.Outs>
     {
-        public class Input
+        public class Ins
         {
             public T TaskContainingSubTasks { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public string[] InjectedSubTaskPropertyNames { get; set; }
         }

--- a/app/Simpler/Core/Tasks/InjectTasks.cs
+++ b/app/Simpler/Core/Tasks/InjectTasks.cs
@@ -6,40 +6,39 @@ namespace Simpler.Core.Tasks
     {
         public class Ins
         {
-            public T TaskContainingSubTasks { get; set; }
+            public T Task { get; set; }
         }
 
         public class Outs
         {
-            public string[] InjectedSubTaskPropertyNames { get; set; }
+            public string[] InjectedTaskPropertyNames { get; set; }
         }
 
         public CreateTask CreateTask { get; set; }
 
         public override void Execute()
         {
-            // This InjectTasks task can't have it's subtasks injected, because it would need to call InjectTasks...I'm getting dizzy.
             if (CreateTask == null) CreateTask = new CreateTask();
 
-            var listOfInjected = new List<string>();
+            var injected = new List<string>();
 
-            var properties = In.TaskContainingSubTasks.GetType().GetProperties();
+            var properties = In.Task.GetType().GetProperties();
             foreach (var propertyX in properties)
             {
                 if (propertyX.PropertyType.IsSubclassOf(typeof(T))
                     && 
-                    (propertyX.CanWrite && propertyX.GetValue(In.TaskContainingSubTasks, null) == null))
+                    (propertyX.CanWrite && propertyX.GetValue(In.Task, null) == null))
                 {
                     CreateTask.In.TaskType = propertyX.PropertyType;
                     CreateTask.Execute();
 
-                    propertyX.SetValue(In.TaskContainingSubTasks, CreateTask.Out.TaskInstance, null);
+                    propertyX.SetValue(In.Task, CreateTask.Out.TaskInstance, null);
 
-                    listOfInjected.Add(propertyX.PropertyType.FullName);
+                    injected.Add(propertyX.PropertyType.FullName);
                 }
             }
 
-            Out.InjectedSubTaskPropertyNames = listOfInjected.ToArray();
+            Out.InjectedTaskPropertyNames = injected.ToArray();
         }
     }
 }

--- a/app/Simpler/Core/Tasks/InjectTasks.cs
+++ b/app/Simpler/Core/Tasks/InjectTasks.cs
@@ -2,11 +2,11 @@ using System.Collections.Generic;
 
 namespace Simpler.Core.Tasks
 {
-    public class InjectTasks : InOutTask<InjectTasks.Input, InjectTasks.Output>
+    public class InjectTasks : IO<InjectTasks.Input, InjectTasks.Output>
     {
         public class Input
         {
-            public Task TaskContainingSubTasks { get; set; }
+            public T TaskContainingSubTasks { get; set; }
         }
 
         public class Output
@@ -26,7 +26,7 @@ namespace Simpler.Core.Tasks
             var properties = In.TaskContainingSubTasks.GetType().GetProperties();
             foreach (var propertyX in properties)
             {
-                if (propertyX.PropertyType.IsSubclassOf(typeof(Task))
+                if (propertyX.PropertyType.IsSubclassOf(typeof(T))
                     && 
                     (propertyX.CanWrite && propertyX.GetValue(In.TaskContainingSubTasks, null) == null))
                 {

--- a/app/Simpler/Data/Db.cs
+++ b/app/Simpler/Data/Db.cs
@@ -31,7 +31,7 @@ namespace Simpler.Data
         {
             var many = new T[] {};
 
-            var execute = Task.New<ExecuteAction>();
+            var execute = Simpler.T.New<ExecuteAction>();
             execute.In.Connection = connection;
             execute.In.Sql = sql;
             execute.In.Values = values;
@@ -40,7 +40,7 @@ namespace Simpler.Data
                     {
                         command.CommandTimeout = timeout;
 
-                        var fetchMany = Task.New<FetchMany<T>>();
+                        var fetchMany = Simpler.T.New<FetchMany<T>>();
                         fetchMany.In.SelectCommand = command;
                         fetchMany.Execute();
                         many = fetchMany.Out.ObjectsFetched;
@@ -54,7 +54,7 @@ namespace Simpler.Data
         {
             var one = default(T);
 
-            var execute = Task.New<ExecuteAction>();
+            var execute = Simpler.T.New<ExecuteAction>();
             execute.In.Connection = connection;
             execute.In.Sql = sql;
             execute.In.Values = values;
@@ -63,7 +63,7 @@ namespace Simpler.Data
                     {
                         command.CommandTimeout = timeout;
 
-                        var fetchMany = Task.New<FetchMany<T>>();
+                        var fetchMany = Simpler.T.New<FetchMany<T>>();
                         fetchMany.In.SelectCommand = command;
                         fetchMany.Execute();
                         one = fetchMany.Out.ObjectsFetched.Single();
@@ -77,7 +77,7 @@ namespace Simpler.Data
         {
             var result = default(int);
 
-            var execute = Task.New<ExecuteAction>();
+            var execute = T.New<ExecuteAction>();
             execute.In.Connection = connection;
             execute.In.Sql = sql;
             execute.In.Values = values;
@@ -97,7 +97,7 @@ namespace Simpler.Data
         {
             var scalar = default(object);
 
-            var execute = Task.New<ExecuteAction>();
+            var execute = T.New<ExecuteAction>();
             execute.In.Connection = connection;
             execute.In.Sql = sql;
             execute.In.Values = values;

--- a/app/Simpler/Data/Tasks/BuildObject.cs
+++ b/app/Simpler/Data/Tasks/BuildObject.cs
@@ -3,7 +3,7 @@ using System.Data;
 
 namespace Simpler.Data.Tasks
 {
-    public class BuildObject<T> : InOutTask<BuildObject<T>.Input, BuildObject<T>.Output> 
+    public class BuildObject<T> : IO<BuildObject<T>.Input, BuildObject<T>.Output> 
     {
         public class Input
         {

--- a/app/Simpler/Data/Tasks/BuildObject.cs
+++ b/app/Simpler/Data/Tasks/BuildObject.cs
@@ -3,14 +3,14 @@ using System.Data;
 
 namespace Simpler.Data.Tasks
 {
-    public class BuildObject<T> : IO<BuildObject<T>.Input, BuildObject<T>.Output> 
+    public class BuildObject<T> : IO<BuildObject<T>.Ins, BuildObject<T>.Outs> 
     {
-        public class Input
+        public class Ins
         {
             public IDataRecord DataRecord { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public T Object { get; set; }
         }

--- a/app/Simpler/Data/Tasks/BuildParameters.cs
+++ b/app/Simpler/Data/Tasks/BuildParameters.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 
 namespace Simpler.Data.Tasks
 {
-    public class BuildParameters : I<BuildParameters.Input>
+    public class BuildParameters : I<BuildParameters.Ins>
     {
-        public class Input
+        public class Ins
         {
             public IDbCommand Command { get; set; }
             public object Values { get; set; }

--- a/app/Simpler/Data/Tasks/BuildParameters.cs
+++ b/app/Simpler/Data/Tasks/BuildParameters.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace Simpler.Data.Tasks
 {
-    public class BuildParameters : InTask<BuildParameters.Input>
+    public class BuildParameters : I<BuildParameters.Input>
     {
         public class Input
         {

--- a/app/Simpler/Data/Tasks/BuildParameters.cs
+++ b/app/Simpler/Data/Tasks/BuildParameters.cs
@@ -22,29 +22,29 @@ namespace Simpler.Data.Tasks
             foreach (var parameterNameX in FindParameters.Out.ParameterNames)
             {
                 var objectType = In.Values.GetType();
-                var objectContainingPropertyValue = In.Values;
+                var values = In.Values;
 
                 // Strip off the first character of the parameter name to find a matching property (e.g. make @Name => Name).
-                var nameOfPropertyContainingValue = parameterNameX.Substring(1);
+                var propertyName = parameterNameX.Substring(1);
 
                 // If the parameter contains a dot then the property must be a complex object, and therefore we must look inside the object to find the value.
                 PropertyInfo property;
-                while(nameOfPropertyContainingValue.Contains("."))
+                while(propertyName.Contains("."))
                 {
                     // Look for a property using the string that comes before the dot.
-                    var indexOfDot = nameOfPropertyContainingValue.IndexOf(".");
-                    property = objectType.GetProperty(nameOfPropertyContainingValue.Substring(0, indexOfDot));
+                    var indexOfDot = propertyName.IndexOf(".");
+                    property = objectType.GetProperty(propertyName.Substring(0, indexOfDot));
 
                     // Apparently there isn't a property that is a complex object that matches the parameter name.
                     if (property == null) break;
 
                     // Reset variables using the property that was found that matched the string that came before the dot. 
                     objectType = property.PropertyType;
-                    objectContainingPropertyValue = property.GetValue(objectContainingPropertyValue, null);
-                    nameOfPropertyContainingValue = nameOfPropertyContainingValue.Substring(indexOfDot + 1);
+                    values = property.GetValue(values, null);
+                    propertyName = propertyName.Substring(indexOfDot + 1);
                 }
 
-                property = objectType.GetProperty(nameOfPropertyContainingValue);
+                property = objectType.GetProperty(propertyName);
 
                 if (property != null)
                 {
@@ -54,7 +54,7 @@ namespace Simpler.Data.Tasks
                     dbDataParameter.ParameterName = parameterNameX.Replace(".", "_");
                     In.Command.CommandText = In.Command.CommandText.Replace(parameterNameX, parameterNameX.Replace(".", "_"));
 
-                    dbDataParameter.Value = property.GetValue(objectContainingPropertyValue, null) ?? DBNull.Value;
+                    dbDataParameter.Value = property.GetValue(values, null) ?? DBNull.Value;
                     In.Command.Parameters.Add(dbDataParameter);
                 }
             }

--- a/app/Simpler/Data/Tasks/ExecuteAction.cs
+++ b/app/Simpler/Data/Tasks/ExecuteAction.cs
@@ -3,9 +3,9 @@ using System.Data;
 
 namespace Simpler.Data.Tasks
 {
-    public class ExecuteAction : I<ExecuteAction.Input>
+    public class ExecuteAction : I<ExecuteAction.Ins>
     {
-        public class Input
+        public class Ins
         {
             public IDbConnection Connection { get; set; }
             public string Sql { get; set; }

--- a/app/Simpler/Data/Tasks/ExecuteAction.cs
+++ b/app/Simpler/Data/Tasks/ExecuteAction.cs
@@ -3,7 +3,7 @@ using System.Data;
 
 namespace Simpler.Data.Tasks
 {
-    public class ExecuteAction : InTask<ExecuteAction.Input>
+    public class ExecuteAction : I<ExecuteAction.Input>
     {
         public class Input
         {

--- a/app/Simpler/Data/Tasks/FetchMany.cs
+++ b/app/Simpler/Data/Tasks/FetchMany.cs
@@ -3,7 +3,7 @@ using System.Data;
 
 namespace Simpler.Data.Tasks
 {
-    public class FetchMany<T> : InOutTask<FetchMany<T>.Input, FetchMany<T>.Output>  
+    public class FetchMany<T> : IO<FetchMany<T>.Input, FetchMany<T>.Output>  
     {
         public class Input
         {

--- a/app/Simpler/Data/Tasks/FetchMany.cs
+++ b/app/Simpler/Data/Tasks/FetchMany.cs
@@ -3,14 +3,14 @@ using System.Data;
 
 namespace Simpler.Data.Tasks
 {
-    public class FetchMany<T> : IO<FetchMany<T>.Input, FetchMany<T>.Output>  
+    public class FetchMany<T> : IO<FetchMany<T>.Ins, FetchMany<T>.Outs>  
     {
-        public class Input
+        public class Ins
         {
             public IDbCommand SelectCommand { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public T[] ObjectsFetched { get; set; }
         }

--- a/app/Simpler/Data/Tasks/FindParameters.cs
+++ b/app/Simpler/Data/Tasks/FindParameters.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Simpler.Data.Tasks
 {
-    public class FindParameters : InOutTask<FindParameters.Input, FindParameters.Output> 
+    public class FindParameters : IO<FindParameters.Input, FindParameters.Output> 
     {
         public class Input
         {

--- a/app/Simpler/Data/Tasks/FindParameters.cs
+++ b/app/Simpler/Data/Tasks/FindParameters.cs
@@ -4,14 +4,14 @@ using System.Collections.Generic;
 
 namespace Simpler.Data.Tasks
 {
-    public class FindParameters : IO<FindParameters.Input, FindParameters.Output> 
+    public class FindParameters : IO<FindParameters.Ins, FindParameters.Outs> 
     {
-        public class Input
+        public class Ins
         {
             public string CommandText { get; set; }
         }
 
-        public class Output
+        public class Outs
         {
             public string[] ParameterNames { get; set; }
         }

--- a/app/Simpler/EventsAttribute.cs
+++ b/app/Simpler/EventsAttribute.cs
@@ -5,8 +5,8 @@ namespace Simpler
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public abstract class EventsAttribute : Attribute
     {
-        public abstract void BeforeExecute(Task task);
-        public abstract void AfterExecute(Task task);
-        public abstract void OnError(Task task, Exception exception);
+        public abstract void BeforeExecute(T task);
+        public abstract void AfterExecute(T task);
+        public abstract void OnError(T task, Exception exception);
     }
 }

--- a/app/Simpler/Fake.cs
+++ b/app/Simpler/Fake.cs
@@ -6,23 +6,23 @@ namespace Simpler
 {
     public class Fake
     {
-        public static TTask Task<TTask>() where TTask : Task
+        public static TTask Task<TTask>() where TTask : T
         {
             return Task<TTask>(execute => {});
         }
 
-        public static TTask Task<TTask>(Action<TTask> execute) where TTask : Task
+        public static TTask Task<TTask>(Action<TTask> execute) where TTask : T
         {
             var interceptor = new ExecuteInterceptor(
                 invocation =>
                     {
-                        var executeTask = Simpler.Task.New<ExecuteTask>();
-                        executeTask.In.Task = (Task)invocation.InvocationTarget;
-                        executeTask.In.Invocation = new FakeInvocation<TTask>((Task)invocation.InvocationTarget, execute);
+                        var executeTask = Simpler.T.New<ExecuteTask>();
+                        executeTask.In.Task = (T)invocation.InvocationTarget;
+                        executeTask.In.Invocation = new FakeInvocation<TTask>((T)invocation.InvocationTarget, execute);
                         executeTask.Execute();
                     });
 
-            var createTask = Simpler.Task.New<CreateTask>();
+            var createTask = Simpler.T.New<CreateTask>();
             createTask.In.TaskType = typeof(TTask);
             createTask.In.ExecuteInterceptor = interceptor;
             createTask.Execute();

--- a/app/Simpler/Fake.cs
+++ b/app/Simpler/Fake.cs
@@ -16,18 +16,18 @@ namespace Simpler
             var interceptor = new ExecuteInterceptor(
                 invocation =>
                     {
-                        var executeTask = Simpler.T.New<ExecuteTask>();
+                        var executeTask = T.New<ExecuteTask>();
                         executeTask.In.Task = (T)invocation.InvocationTarget;
                         executeTask.In.Invocation = new FakeInvocation<TTask>((T)invocation.InvocationTarget, execute);
                         executeTask.Execute();
                     });
 
-            var createTask = Simpler.T.New<CreateTask>();
-            createTask.In.TaskType = typeof(TTask);
-            createTask.In.ExecuteInterceptor = interceptor;
-            createTask.Execute();
+            var create = T.New<CreateTask>();
+            create.In.TaskType = typeof(TTask);
+            create.In.ExecuteInterceptor = interceptor;
+            create.Execute();
 
-            return (TTask)createTask.Out.TaskInstance;
+            return (TTask)create.Out.TaskInstance;
         }
     }
 }

--- a/app/Simpler/I.cs
+++ b/app/Simpler/I.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Simpler
 {
-    public abstract class InTask<TIn> : Task 
+    public abstract class I<TIn> : T 
     {
         TIn _in;
         public virtual TIn In

--- a/app/Simpler/IO.cs
+++ b/app/Simpler/IO.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Simpler
 {
-    public abstract class InOutTask<TIn, TOut> : Task
+    public abstract class IO<TIn, TOut> : T
     {
         TIn _in;
         public virtual TIn In

--- a/app/Simpler/O.cs
+++ b/app/Simpler/O.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Simpler
 {
-    public abstract class OutTask<TOut> : Task
+    public abstract class O<TOut> : T
     {
         TOut _out;
         public TOut Out

--- a/app/Simpler/Simpler.csproj
+++ b/app/Simpler/Simpler.csproj
@@ -65,13 +65,14 @@
     <Compile Include="Data\Tasks\BuildObject.cs" />
     <Compile Include="Core\Tasks\ExecuteTask.cs" />
     <Compile Include="Core\Tasks\CreateTask.cs" />
-    <Compile Include="InOutTask.cs" />
-    <Compile Include="InTask.cs" />
-    <Compile Include="OutTask.cs" />
+    <Compile Include="IO.cs" />
+    <Compile Include="I.cs" />
+    <Compile Include="O.cs" />
     <Compile Include="Stats.cs" />
-    <Compile Include="Task.cs" />
+    <Compile Include="T.cs" />
     <Compile Include="OverrideAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Wordy.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/app/Simpler/T.cs
+++ b/app/Simpler/T.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace Simpler
 {
     [InjectTasks]
-    public abstract class Task
+    public abstract class T
     {
         public static T New<T>()
         {

--- a/app/Simpler/Wordy.cs
+++ b/app/Simpler/Wordy.cs
@@ -1,7 +1,7 @@
 ﻿namespace Simpler.Wordy
 {
     public abstract class Task : T { }
-    public abstract class InTask<TIn> : Simpler.I<TIn> { }
-    public abstract class OutTask<TOut> : Simpler.O<TOut> { }
+    public abstract class InTask<TIn> : I<TIn> { }
+    public abstract class OutTask<TOut> : O<TOut> { }
     public abstract class InOutTask<TIn, TOut> : IO<TIn, TOut> { }
 }

--- a/app/Simpler/Wordy.cs
+++ b/app/Simpler/Wordy.cs
@@ -1,0 +1,7 @@
+﻿namespace Simpler.Wordy
+{
+    public abstract class Task : T { }
+    public abstract class InTask<TIn> : Simpler.I<TIn> { }
+    public abstract class OutTask<TOut> : Simpler.O<TOut> { }
+    public abstract class InOutTask<TIn, TOut> : IO<TIn, TOut> { }
+}


### PR DESCRIPTION
`T`, `I`, `O`, and `IO` replace `Task`, `InTask`, `OutTask`, and `InOutTask`. The wordy names for these classes are preserved in `Simpler.Wordy`.

These four classes are used over and over again so switching to the one or two letter class names reduces clutter in files. 

This also sidesteps namespace issues with `System.Threading.Tasks.Task`.
